### PR TITLE
chore: unified prefix for ESM import node core module

### DIFF
--- a/src/core/code-review/index.ts
+++ b/src/core/code-review/index.ts
@@ -1,4 +1,4 @@
-import { promises as fs } from 'fs';
+import { promises as fs } from 'node:fs';
 import { intro, outro, spinner } from '@clack/prompts';
 import path from 'node:path';
 import chalk from 'chalk';

--- a/src/core/commit/index.ts
+++ b/src/core/commit/index.ts
@@ -1,5 +1,5 @@
 // import fs from 'node:fs';
-import { promises as fs } from 'fs';
+import { promises as fs } from 'node:fs';
 import { cancel, intro, spinner } from '@clack/prompts';
 import chalk from 'chalk';
 

--- a/src/core/components/index.ts
+++ b/src/core/components/index.ts
@@ -1,5 +1,5 @@
-import { promises as fs } from 'fs';
-import path from 'path';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
 import { marked } from 'marked';
 import { outro, spinner } from '@clack/prompts';
 

--- a/src/core/config/index.ts
+++ b/src/core/config/index.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 

--- a/src/core/hooks/index.ts
+++ b/src/core/hooks/index.ts
@@ -1,7 +1,7 @@
 import { outro, spinner } from '@clack/prompts';
 import { marked } from 'marked';
-import path from 'path';
-import { promises as fs } from 'fs';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
 
 import { getConfig } from '../config';
 

--- a/src/core/model/utils.ts
+++ b/src/core/model/utils.ts
@@ -1,5 +1,5 @@
 import * as cheerio from 'cheerio';
-import { promises as fs } from 'fs';
+import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { ModelResponse } from 'ollama';

--- a/src/core/ollama/index.ts
+++ b/src/core/ollama/index.ts
@@ -1,9 +1,8 @@
-import { exec, execSync } from 'child_process';
-import { promisify } from 'util';
+import { exec, execSync, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
 import { confirm } from '@clack/prompts';
-import { spawn } from 'child_process';
 import path from 'node:path';
-import fs from 'fs';
+import fs from 'node:fs';
 
 import { setConfig } from '@/core/config';
 import { openBrowser, currentPlatform, oraSpinner, log } from '@/utils';

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -1,7 +1,7 @@
-import { execSync, spawn } from 'child_process';
+import { execSync, spawn } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
-import { promises as fs } from 'fs';
+import { promises as fs } from 'node:fs';
 
 import { Staged } from '@/types';
 /**


### PR DESCRIPTION
Why Use the  Prefix?node:
Clarity: It makes it clear that the module is a Node.js core module.
Avoid Conflicts: It helps prevent conflicts with third-party packages that might have the same name as a core module.
Future-proofing: This is the direction that Node.js is moving towards, and it's good to adopt the best practices early.